### PR TITLE
avutil/mem: Fix invalid use of av_alloc_size

### DIFF
--- a/libavutil/mem.h
+++ b/libavutil/mem.h
@@ -338,7 +338,7 @@ av_alloc_size(2, 3) void *av_realloc_array(void *ptr, size_t nmemb, size_t size)
  * @warning Unlike av_malloc(), the allocated memory is not guaranteed to be
  *          correctly aligned.
  */
-av_alloc_size(2, 3) int av_reallocp_array(void *ptr, size_t nmemb, size_t size);
+int av_reallocp_array(void *ptr, size_t nmemb, size_t size);
 
 /**
  * Reallocate the given buffer if it is not large enough, otherwise do nothing.


### PR DESCRIPTION
The alloc_size attribute is valid only on functions that return a
pointer.  GCC 9 (not yet released) warns about invalid usage:

./libavutil/mem.h:342:1: warning: 'alloc_size' attribute ignored on a function returning int' [-Wattributes]
  342 | av_alloc_size(2, 3) int av_reallocp_array(void *ptr, size_t nmemb, size_t size);
      | ^~~~~~~~~~~~~

Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
(cherry picked from commit 4361293fcf59edb56879c36edcd25f0a91e0edf8)